### PR TITLE
Logger

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,10 @@ include_directories(include)
 
 # Add the directories for libraries
 add_subdirectory(src/networking)
+add_subdirectory(src/logger)
 
 # Build the main executable
 add_executable(resfet src/main.cpp)
 
 # Link the libraries
-target_link_libraries(resfet networking)
+target_link_libraries(resfet networking logger)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,9 +8,10 @@ include_directories(include)
 # Add the directories for libraries
 add_subdirectory(src/networking)
 add_subdirectory(src/logger)
+add_subdirectory(src/time)
 
 # Build the main executable
 add_executable(resfet src/main.cpp)
 
 # Link the libraries
-target_link_libraries(resfet networking logger)
+target_link_libraries(resfet networking logger time)

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -1,0 +1,109 @@
+/**
+ * @file logger.hpp
+ * @author Tommy Yuan (ty19@rice.edu)
+ * @brief Logger with debug levels.
+ * @version 0.1
+ * @date 2019-07-08
+ * 
+ * @copyright Copyright (c) 2019
+ * 
+ */
+
+#ifndef __LOGGER_HPP
+#define __LOGGER_HPP
+
+// Maximum length of a log message
+#define MAX_LOG_LEN 128
+
+// Maximum length of the filename of the log
+#define MAX_FILENAME_LEN 64
+
+/*
+ * The log levels that determine what messages are send to
+ * stdout. TODO Should we use the same logger class to log
+ * data? Data should be logged at all log levels.
+ *
+ * In order of least to most output:
+ * SILENT: No messages.
+ * ERROR: Errors that prevent continued operation.
+ * INFO: Errors and important events
+ * DEBUG: INFO plus additional debug messages.
+ */
+enum LogLevel {
+	SILENT = 0,
+	ERROR = 1,
+	INFO = 2,
+	DEBUG = 3
+};
+
+const char LogLevelStrings[][7] = {"SILENT",
+			   "ERROR",
+			   "INFO",
+			   "DEBUG"};
+
+/*
+ * TODO each instance has only one filename and file descriptor.
+ * If we want to use fewer loggers we can provide the file in the
+ * function calls instead of the constructor.
+ *
+ * A logger class that handles different log levels and logging 
+ * options.
+ */
+class Logger {
+	private:
+		/* @brief The name of this logger */
+		const char *name;
+
+		/* @brief The filename of the log file to write to. */
+		const char *filename;
+
+		/* @brief The file descriptor to write to. */
+		int file_fd;
+
+		/* @brief The log level of this logger */
+		LogLevel log_level;
+
+
+	public:
+
+		/*
+		 * @brief Constructor for the logger.
+		 */
+		Logger(const char *name, const char *filename, LogLevel log_level);
+
+		/*
+		 * @brief Attempts to create a log file and any intermediate directories.
+		 * 		  The default directory is logs/filename, where the logs/ directory
+		 * 		  is relative to the current working directory.
+		 * @return 1 on success and 0 on failure.
+		 */
+		int create_log_file();
+
+		/*
+		 * @brief Logs a message if the logger's log level is at least as high
+		 * 		  as the provided log level. 
+		 * @msg	  The message to log.
+		 * @param level The log level of the message.
+		 */
+		void log(const char *msg, LogLevel level);
+
+		/*
+		 * @brief Logs an ERROR level message.
+		 * @msg	  The message to log.
+		 */
+		void error(const char *msg);
+
+		/*
+		 * @brief Logs an INFO level message.
+		 * @msg	  The message to log.
+		 */
+		void info(const char *msg);
+
+		/*
+		 * @brief Logs a DEBUG level message.
+		 * @msg	  The message to log.
+		 */
+		void debug(const char *msg);
+};
+
+#endif

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -6,7 +6,6 @@
  * @date 2019-07-08
  * 
  * @copyright Copyright (c) 2019
- * 
  */
 
 #ifndef __LOGGER_HPP
@@ -56,7 +55,7 @@ class Logger {
 		const char *name;
 
 		/* @brief The filename of the log file to write to */
-		const char *filename;
+		char *filename;
 
 		/* @brief The file descriptor to write to */
 		int file_fd;
@@ -80,7 +79,7 @@ class Logger {
 		/*
 		 * @brief Constructor for the logger.
 		 */
-		Logger(const char *name, const char *filename, LogLevel log_level);
+		Logger(const char *name, char *filename, LogLevel log_level);
 
 		/*
 		 * @brief Logs a message if the logger's log level is at least as high

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -25,7 +25,7 @@
  * In order of least to most output:
  * SILENT: No messages.
  * ERROR: Errors that prevent continued operation.
- * INFO: Errors and important events
+ * INFO: Errors and important events.
  * DEBUG: INFO plus additional debug messages.
  */
 enum LogLevel {
@@ -35,10 +35,12 @@ enum LogLevel {
 	DEBUG = 3
 };
 
-const char LogLevelStrings[][7] = {"SILENT",
-			   "ERROR",
-			   "INFO",
-			   "DEBUG"};
+const char LogLevelStrings[][7] ={
+	"SILENT",
+	"ERROR",
+	"INFO",
+	"DEBUG"
+};
 
 /*
  * TODO each instance has only one filename and file descriptor.
@@ -53,10 +55,10 @@ class Logger {
 		/* @brief The name of this logger */
 		const char *name;
 
-		/* @brief The filename of the log file to write to. */
+		/* @brief The filename of the log file to write to */
 		const char *filename;
 
-		/* @brief The file descriptor to write to. */
+		/* @brief The file descriptor to write to */
 		int file_fd;
 
 		/* @brief The log level of this logger */
@@ -67,8 +69,8 @@ class Logger {
 
 		/*
 		 * @brief Attempts to create a log file and any intermediate directories.
-		 * 		  The default directory is logs/filename, where the logs/ directory
-		 * 		  is relative to the current working directory.
+		 * 	  The default directory is logs/filename, where the logs/ directory
+		 * 	  is relative to the current working directory.
 		 * @return 1 on success and 0 on failure.
 		 */
 		int create_log_file();
@@ -82,7 +84,7 @@ class Logger {
 
 		/*
 		 * @brief Logs a message if the logger's log level is at least as high
-		 * 		  as the provided log level. 
+		 * 	  as the provided log level. 
 		 * @msg	  The message to log.
 		 * @param level The log level of the message.
 		 */

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -55,7 +55,7 @@ class Logger {
 		const char *name;
 
 		/* @brief The filename of the log file to write to */
-		char *filename;
+		char filename[MAX_BUF_LEN];
 
 		/* @brief The file descriptor to write to */
 		int file_fd;
@@ -79,7 +79,7 @@ class Logger {
 		/*
 		 * @brief Constructor for the logger.
 		 */
-		Logger(const char *name, char *filename, LogLevel log_level);
+		Logger(const char *name, const char *filename, LogLevel log_level);
 
 		/*
 		 * @brief Logs a message if the logger's log level is at least as high

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -16,10 +16,10 @@
 
 #include <stdarg.h>
 
-/*
- * The log levels that determine what messages are send to
- * stdout. TODO Should we use the same logger class to log
- * data? Data should be logged at all log levels.
+/**
+ * @brief The log levels that determine what messages are send to
+ * 		  stdout. TODO Should we use the same logger class to log
+ * 		  data? Data should be logged at all log levels.
  *
  * In order of least to most output:
  * SILENT: No messages.
@@ -41,35 +41,46 @@ const char LogLevelStrings[][7] ={
 	"DEBUG"
 };
 
-/*
+/**
+ * @brief A logger class that handles different log levels and logging 
+ * 		  options.
+ * 
  * TODO each instance has only one filename and file descriptor.
  * If we want to use fewer loggers we can provide the file in the
  * function calls instead of the constructor.
- *
- * A logger class that handles different log levels and logging 
- * options.
  */
 class Logger {
 	private:
-		/* @brief The name of this logger */
+		/**
+		 * @brief The name of this logger
+		 */
 		const char *name;
 
-		/* @brief The filename of the log file to write to */
+		/**
+		 * @brief The filename of the log file to write to
+		 */
 		char filename[MAX_BUF_LEN];
 
-		/* @brief The file descriptor to write to */
+		/** 
+		 * @brief The file descriptor to write to
+		 */
 		int file_fd;
 
-		/* @brief The log level of this logger */
+		/**
+		 * @brief The log level of this logger
+		 */
 		LogLevel log_level;
 
-		/* @brief A temporary buffer that is used to format user input */
+		/**
+		 * @brief A temporary buffer that is used to format user input
+		 */
 		char buf[MAX_BUF_LEN];
 
 		/*
 		 * @brief Attempts to create a log file and any intermediate directories.
-		 * 	  The default directory is logs/filename, where the logs/ directory
-		 * 	  is relative to the current working directory.
+		 * 	  	  The default directory is logs/filename, where the logs/ directory
+		 * 	  	  is relative to the current working directory.
+		 * 
 		 * @return 1 on success and 0 on failure.
 		 */
 		int create_log_file();
@@ -83,7 +94,7 @@ class Logger {
 
 		/*
 		 * @brief Logs a message if the logger's log level is at least as high
-		 * 	  as the provided log level. 
+		 * 	  	  as the provided log level. 
 		 * @msg	  The message to log.
 		 * @param level The log level of the message.
 		 */

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -12,11 +12,10 @@
 #ifndef __LOGGER_HPP
 #define __LOGGER_HPP
 
-// Maximum length of a log message
-#define MAX_LOG_LEN 128
+// Maximum length of a formatted log message
+#define MAX_BUF_LEN 256
 
-// Maximum length of the filename of the log
-#define MAX_FILENAME_LEN 64
+#include <stdarg.h>
 
 /*
  * The log levels that determine what messages are send to
@@ -63,13 +62,8 @@ class Logger {
 		/* @brief The log level of this logger */
 		LogLevel log_level;
 
-
-	public:
-
-		/*
-		 * @brief Constructor for the logger.
-		 */
-		Logger(const char *name, const char *filename, LogLevel log_level);
+		/* @brief A temporary buffer that is used to format user input */
+		char buf[MAX_BUF_LEN];
 
 		/*
 		 * @brief Attempts to create a log file and any intermediate directories.
@@ -79,31 +73,38 @@ class Logger {
 		 */
 		int create_log_file();
 
+	public:
+
+		/*
+		 * @brief Constructor for the logger.
+		 */
+		Logger(const char *name, const char *filename, LogLevel log_level);
+
 		/*
 		 * @brief Logs a message if the logger's log level is at least as high
 		 * 		  as the provided log level. 
 		 * @msg	  The message to log.
 		 * @param level The log level of the message.
 		 */
-		void log(const char *msg, LogLevel level);
+		void log(const char *format, LogLevel level, va_list argList);
 
 		/*
 		 * @brief Logs an ERROR level message.
 		 * @msg	  The message to log.
 		 */
-		void error(const char *msg);
+		void error(const char *format, ...);
 
 		/*
 		 * @brief Logs an INFO level message.
 		 * @msg	  The message to log.
 		 */
-		void info(const char *msg);
+		void info(const char *format, ...);
 
 		/*
 		 * @brief Logs a DEBUG level message.
 		 * @msg	  The message to log.
 		 */
-		void debug(const char *msg);
+		void debug(const char *format, ...);
 };
 
 #endif

--- a/include/time/time.hpp
+++ b/include/time/time.hpp
@@ -1,0 +1,34 @@
+/**
+ * @file time.h
+ * @author Tommy Yuan (ty19@rice.edu)
+ * @brief A set of functions for determining and formatting timestamps.
+ * @version 0.1
+ * @date 2019-07-09
+ * 
+ * @copyright Copyright (c) 2019
+ */
+
+#include <stdint.h>
+
+#define MAX_TIME_BUF_LEN 128
+
+/* A long time in nanoseconds */
+typedef uint64_t timestamp_t;
+
+/* @brief Sets the start time if it has not been set already */
+void set_start_time();
+
+/* @brief Gets time formatted according to ISO 8601 */
+void get_formatted_time(char *time_buf);
+
+/* @brief Gets the elapsed time in seconds */
+timestamp_t get_elapsed_time_s();
+
+/* @brief Gets the elapsed time in milliseconds */
+timestamp_t get_elapsed_time_ms();
+
+/* @brief Gets the elapsed time in microseconds */
+timestamp_t get_elapsed_time_us();
+
+/* @brief Gets the elapsed time in nanoseconds */
+timestamp_t get_elapsed_time_ns();

--- a/include/time/time.hpp
+++ b/include/time/time.hpp
@@ -1,5 +1,5 @@
 /**
- * @file time.h
+ * @file time.hpp
  * @author Tommy Yuan (ty19@rice.edu)
  * @brief A set of functions for determining and formatting timestamps.
  * @version 0.1
@@ -15,20 +15,32 @@
 /* A long time in nanoseconds */
 typedef uint64_t timestamp_t;
 
-/* @brief Sets the start time if it has not been set already */
+/**
+ * @brief Sets the start time if it has not been set already
+ */
 void set_start_time();
 
-/* @brief Gets time formatted according to ISO 8601 */
+/**
+ * @brief Gets time formatted according to ISO 8601 
+ */
 void get_formatted_time(char *time_buf);
 
-/* @brief Gets the elapsed time in seconds */
+/**
+ * @brief Gets the elapsed time in seconds 
+ */
 timestamp_t get_elapsed_time_s();
 
-/* @brief Gets the elapsed time in milliseconds */
+/**
+ * @brief Gets the elapsed time in milliseconds 
+ */
 timestamp_t get_elapsed_time_ms();
 
-/* @brief Gets the elapsed time in microseconds */
+/**
+ * @brief Gets the elapsed time in microseconds 
+ */
 timestamp_t get_elapsed_time_us();
 
-/* @brief Gets the elapsed time in nanoseconds */
+/**
+ * @brief Gets the elapsed time in nanoseconds 
+ */
 timestamp_t get_elapsed_time_ns();

--- a/src/logger/CMakeLists.txt
+++ b/src/logger/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Create the logger library
+add_library(logger STATIC logger.cpp)

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -41,18 +41,6 @@ int Logger::create_log_file() {
 		return -1;
 	}
 
-	if (dup2(STDOUT_FILENO, file_fd) == -1) {
-		dprintf(STDERR_FILENO, "stdout dup2 unsuccessful: %s\n",
-				strerror(errno));
-		return -1;
-	}
-
-	if (dup2(STDERR_FILENO, file_fd) == -1) {
-		dprintf(STDERR_FILENO, "stderr dup2 unsuccessful: %s\n",
-				strerror(errno));
-		return -1;
-	}
-
 	return 0;
 }
 
@@ -67,6 +55,8 @@ void Logger::log(const char *msg, LogLevel level) {
 
 	// TODO time
 	dprintf(file_fd, "[%s][%s][%s] %s", name, LogLevelStrings[(int)level], "time", msg);
+
+	dprintf(STDOUT_FILENO, "[%s][%s][%s] %s", name, LogLevelStrings[(int)level], "time", msg);
 }
 
 void Logger::error(const char *msg) {

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -1,0 +1,82 @@
+/**
+ * @file logger.cpp
+ * @author Tommy Yuan (ty19@rice.edu)
+ * @brief Implementation of classes and methods in logger.hpp.
+ * @version 0.1
+ * @date 2019-07-08
+ * 
+ * @copyright Copyright (c) 2019
+ * 
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h> 
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "logger/logger.hpp"
+
+Logger::Logger(const char *name, const char *filename, LogLevel log_level)
+	: name(name)
+  	, filename(filename)
+	, log_level(log_level)
+	, file_fd(-1)
+  	{
+		create_log_file();
+	}
+
+int Logger::create_log_file() {	
+	struct stat st;
+
+	if (stat("logs", &st) == -1)
+		mkdir("logs", 0700);
+	
+
+	if ((file_fd = open(filename, O_CREAT | O_RDWR | O_TRUNC)) == -1) {
+		dprintf(STDERR_FILENO, "Create log file unsuccessful: %s\n",
+				strerror(errno));
+		return -1;
+	}
+
+	if (dup2(STDOUT_FILENO, file_fd) == -1) {
+		dprintf(STDERR_FILENO, "stdout dup2 unsuccessful: %s\n",
+				strerror(errno));
+		return -1;
+	}
+
+	if (dup2(STDERR_FILENO, file_fd) == -1) {
+		dprintf(STDERR_FILENO, "stderr dup2 unsuccessful: %s\n",
+				strerror(errno));
+		return -1;
+	}
+
+	return 0;
+}
+
+void Logger::log(const char *msg, LogLevel level) {
+	if (file_fd == -1) {
+		dprintf(STDERR_FILENO, "Attempting to log when log file is null\n");
+		return;
+	}
+
+	if (log_level < level)
+		return;
+
+	// TODO time
+	dprintf(file_fd, "[%s][%s][%s] %s", name, LogLevelStrings[(int)level], "time", msg);
+}
+
+void Logger::error(const char *msg) {
+	log(msg, LogLevel::ERROR);
+}
+
+void Logger::info(const char *msg) {
+	log(msg, LogLevel::INFO);
+}
+
+void Logger::debug(const char *msg) {
+	log(msg, LogLevel::DEBUG);
+}

--- a/src/logger/logger.cpp
+++ b/src/logger/logger.cpp
@@ -18,16 +18,23 @@
 #include <unistd.h>
 
 #include "logger/logger.hpp"
+#include "time/time.hpp"
 
-Logger::Logger(const char *name, const char *filename, LogLevel log_level)
+Logger::Logger(const char *name, char *filename, LogLevel log_level)
 	: name(name)
-  	, filename(filename)
+	, filename(filename)
 	, log_level(log_level)
 	, file_fd(-1)
   	{
+		char time_buf[MAX_TIME_BUF_LEN];
+
+		/* Start the timer and append the time to the filename */
+		set_start_time();
+		get_formatted_time(time_buf);
+		strcat(this->filename, "_");
+		strcat(this->filename, time_buf);
 		create_log_file();
 		// TODO write any initial info (e.g. config files) to the log file
-		// TODO append the time string to the filename
 	}
 
 int Logger::create_log_file() {	
@@ -46,7 +53,7 @@ int Logger::create_log_file() {
 	 * This assumes there are no shared filenames since they should
 	 * contain the time of creation.
 	 */
-	if ((file_fd = open(filename, O_CREAT | O_RDWR | O_TRUNC)) == -1) {
+	if ((file_fd = open(filename, O_CREAT | O_RDWR | O_TRUNC), 0700) == -1) {
 		dprintf(STDERR_FILENO, "Create log file unsuccessful: %s\n",
 				strerror(errno));
 		return -1;
@@ -72,10 +79,10 @@ void Logger::log(const char *format, LogLevel level, va_list argList) {
 	// TODO time
 	
 	/* Write the formatted message, and other information, to the log file */
-	dprintf(file_fd, "[%s][%s][%s] %s", name, LogLevelStrings[level], "time", buf);
+	dprintf(file_fd, "[%s][%s][%lu] %s", name, LogLevelStrings[level], get_elapsed_time_ms(), buf);
 
 	/* Write to stdout */
-	dprintf(STDOUT_FILENO, "[%s][%s][%s] %s", name, LogLevelStrings[level], "time", buf);
+	dprintf(STDOUT_FILENO, "[%s][%s][%lu] %s", name, LogLevelStrings[level], get_elapsed_time_ms(), buf);
 }
 
 void Logger::error(const char *format, ...) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,15 @@
 #include <cstdint>
 #include <iostream>
+#include <string.h>
 
 #include "networking/Tcp.hpp"
 #include "logger/logger.hpp"
 
 // Simple recv test for TCP interface
 int main() {
-
-    std::string send_string;
-    Logger network_logger ("Networking", "NetworkLog", LogLevel::DEBUG);
+    char fname[MAX_BUF_LEN];
+    strcpy(fname, "NetworkLog");
+    Logger network_logger ("Networking", fname, LogLevel::DEBUG);
 
     // Try to open a socket for listening
     Tcp::ListenSocket liSock;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,21 +30,16 @@ int main() {
             return -1;
         }
 		network_logger.info("Connected to client!\n");
-
-		send_string = "Hostname: " + coSock.getClientHostname() + "\n";
-		network_logger.info(send_string.c_str());
-
-		send_string = "Service: " + coSock.getClientService() + "\n";
-		network_logger.info(send_string.c_str());
+		network_logger.info("Hostname: %s\n", coSock.getClientHostname().c_str());
+		network_logger.info("Service: %s\n", coSock.getClientService().c_str());
         
         // Read individual bytes until '0', then quit and wait for another request
         uint8_t read;
         try {
             while ((read = coSock.recvByte()) != '0') {
-		send_string = "Read byte: " + std::string((char *)&read) + "\n";
-		network_logger.info(send_string.c_str());
+		network_logger.info("Read byte: %c\n", read);
             }
-		send_string = "Read 0: " + std::string((char *)&read) + "\n";
+		network_logger.info("Read 0: %c\n", read);
         } catch (Tcp::ClientDisconnectException&) {
 		network_logger.info("Client disconnected prematurely, waiting for new connection...\n");
         } catch (Tcp::OpFailureException&) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,9 +7,7 @@
 
 // Simple recv test for TCP interface
 int main() {
-    char fname[MAX_BUF_LEN];
-    strcpy(fname, "NetworkLog");
-    Logger network_logger ("Networking", fname, LogLevel::DEBUG);
+    Logger network_logger ("Networking", "NetworkLog", LogLevel::DEBUG);
 
     // Try to open a socket for listening
     Tcp::ListenSocket liSock;

--- a/src/time/CMakeLists.txt
+++ b/src/time/CMakeLists.txt
@@ -1,0 +1,2 @@
+# Create the time library
+add_library(time STATIC time.cpp)

--- a/src/time/time.cpp
+++ b/src/time/time.cpp
@@ -1,5 +1,5 @@
 /**
- * @file time.c
+ * @file time.cpp
  * @author Tommy Yuan (ty19@rice.edu)
  * @brief A set of functions for determining and formatting timestamps.
  * @version 0.1

--- a/src/time/time.cpp
+++ b/src/time/time.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file time.c
+ * @author Tommy Yuan (ty19@rice.edu)
+ * @brief A set of functions for determining and formatting timestamps.
+ * @version 0.1
+ * @date 2019-07-09
+ * 
+ * @copyright Copyright (c) 2019
+ */
+
+#include <stdio.h>
+#include <time.h>
+
+#include "time/time.hpp"
+
+static timestamp_t start_time = 0;
+
+void set_start_time() {
+	if (start_time == 0) {
+		start_time = get_elapsed_time_ns();
+	}
+}
+
+void get_formatted_time(char *time_buf) {
+	struct tm date;
+	struct timespec tp;
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+
+	localtime_r((const time_t *)&tp.tv_sec, &date);
+
+	// TODO daylight savings?
+	snprintf(time_buf, MAX_TIME_BUF_LEN, "%04d-%02d-%02dT%02d:%02d:%02d",
+		 date.tm_year + 1900, date.tm_mon + 1, date.tm_mday,
+		 date.tm_hour, date.tm_min, date.tm_sec);
+}
+
+timestamp_t get_elapsed_time_s() {
+	return get_elapsed_time_ms() / 1000;
+}
+
+timestamp_t get_elapsed_time_ms() {
+	return get_elapsed_time_us() / 1000;
+}
+
+timestamp_t get_elapsed_time_us() {
+	return get_elapsed_time_ns() / 1000;
+}
+
+timestamp_t get_elapsed_time_ns() {
+	struct timespec tp;
+
+	clock_gettime(CLOCK_REALTIME, &tp);
+	return (uint64_t)tp.tv_sec * 1000000000 + (uint64_t)tp.tv_nsec - start_time;
+}


### PR DESCRIPTION
Logger and time libraries that have most of the functionality of the old utilities, with a few additions. The logger now creates the logs/ directory if it doesn't exist and names log files with the time of creation. The time library can create formatted messages according to basic ISO 8601 and outputs elapsed time in ns/us/ms/s. 

Potential Changes:
Log header is kind of verbose. Current format is [Logger Name][Log Level][Timestamp] Message. The timestamp is also in ms. We may want to use s for the printouts to be more readable but ns for the files to have the most accuracy.

Each logger is also associated with only one file, which will be tedious if we use what we currently have for logging data. The logger was used for network and valve actuation messages, not data, in mk1-1-engine-controller.

Closes #2