### PR TITLE
Persistent ignition thread

### DIFF
--- a/src/adc/adc.cpp
+++ b/src/adc/adc.cpp
@@ -15,6 +15,9 @@
 
 #include "adc/adc.hpp"
 
+/**
+ * @brief Global lock to ensure sequential ADC reads.
+ */
 std::mutex adc_mutex;
 
 /**


### PR DESCRIPTION
Ignition monitor thread is now created on worker visitor construction and remains active until the program ends. Avoids an anomalous crash on the Pi related to closing threads.